### PR TITLE
Fix warnings due to undefined index "class" in theme_table()

### DIFF
--- a/includes/theme.inc
+++ b/includes/theme.inc
@@ -2136,7 +2136,7 @@ function theme_table(array $variables) {
         // Add odd/even class.
         if (!$no_striping) {
           $class = $flip[$class];
-          if (!is_array($attributes['class'])) {
+          if (!isset($attributes['class']) || !is_array($attributes['class'])) {
             $attributes['class'] = array();
           }
           $attributes['class'][] = $class;


### PR DESCRIPTION
In https://github.com/omega8cc/7x/commit/0cec53b07a33e4000a84d4a199806628cbe478f1 an array check is added on `$attributes['class']`, without testing whether the element `class` is actually defined. Hence the following notice:

> Notice: Undefined index: class in theme_table() (line 2139 of /var/www/project/builds/20190626-162121/includes/theme.inc).

This pull request adds an extra check.