### PR TITLE
Revert changes to drupal_pre_render_scripts().

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -4548,7 +4548,13 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
  * @see drupal_get_js()
  */
 function drupal_pre_render_scripts(array $elements) {
-  $preprocess_js = (variable_get('preprocess_js', FALSE) && !defined('MAINTENANCE_MODE'));
+  // Group and aggregate the items.
+  if (isset($elements['#group_callback'])) {
+    $elements['#groups'] = $elements['#group_callback']($elements['#items']);
+  }
+  if (isset($elements['#aggregate_callback'])) {
+    $elements['#aggregate_callback']($elements['#groups']);
+  }
 
   // A dummy query-string is added to filenames, to gain control over
   // browser-caching. The string changes on every update or full cache


### PR DESCRIPTION
The commit 8e84e47d2c378a8e33b4b0822ceefdb863875c12 broke aggregation of javascript. This code reverts the drupal_pre_render_scripts() function to its previous version.